### PR TITLE
Update to_feature to return the expected object

### DIFF
--- a/mds/json.py
+++ b/mds/json.py
@@ -41,8 +41,7 @@ def extract_point(feature):
     """
     Extract the coordinates from the given GeoJSON :feature: as a shapely.geometry.Point
     """
-    coords = feature["geometry"]["coordinates"]
-    return shapely.geometry.Point(coords[0], coords[1])
+    return shapely.geometry.shape(feature)
 
 def to_feature(shape, properties={}):
     """
@@ -52,12 +51,13 @@ def to_feature(shape, properties={}):
     """
     feature = shapely.geometry.mapping(shape)
     feature["properties"] = properties
+    feature["geometry"] = {}
 
     if isinstance(shape, shapely.geometry.Point):
-        feature["coordinates"] = list(feature["coordinates"])
+        feature["geometry"]["coordinates"] = list(feature["coordinates"])
     else:
         # assume shape is polygon (multipolygon will break)
-        feature["coordinates"] = [list(list(coords) for coords in part) for part in feature["coordinates"]]
+        feature["geometry"]["coordinates"] = [list(list(coords) for coords in part) for part in feature["coordinates"]]
 
     return feature
 
@@ -125,7 +125,7 @@ class CustomJsonEncoder(json.JSONEncoder):
             else:
                 return str(obj)
 
-        if isinstance(obj, Point) or isinstance(obj, Polygon):
+        if isinstance(obj, shapely.geometry.Point) or isinstance(obj, shapely.geometry.Polygon):
             return to_feature(obj)
 
         if isinstance(obj, tuple):


### PR DESCRIPTION
Also upstream https://github.com/CityofSantaMonica/mds-provider/pull/63

According to http://geojson.org/, the Feature geojson expects
that coordinates be nested under geometry. `to_feature` was originally
creating objects where the coordinates were not nested, leading to
KeyErrors when `extract_point` is called.

Also updated `extract_point` to use the shapely function `shape` to
convert the object to a shapely Point instead of pulling the coordinates
out unnecessarily and then creating a Point.