### PR TITLE
Method doesn't generate valid geoJSON

### DIFF
--- a/mds/json.py
+++ b/mds/json.py
@@ -59,6 +59,11 @@ def to_feature(shape, properties={}):
         # assume shape is polygon (multipolygon will break)
         feature["geometry"]["coordinates"] = [list(list(coords) for coords in part) for part in feature["coordinates"]]
 
+    # 'type' at the top level is Feature, and in 'geometry' should be set
+    feature["geometry"]["type"] = feature["type"]
+    feature["type"] = "Feature"
+    # 'coordinates' in the top level is not valid geoJSON.
+    feature.pop('coordinates')
     return feature
 
 def read_data_file(src, record_type):


### PR DESCRIPTION
Compare results of:

```
import shapely
from mds.json import parse_boundary, to_feature
from mds.fake import geometry
boundary = parse_boundary('https://gist.githubusercontent.com/rgangopadhya/6b38d2a7af5c75ebda68ce2aa7393f79/raw/be047c39d4e11454fda58abc747aeba30bf88a8c/sm.geojson')
point = geometry.point_within(boundary)
feature = to_feature(point, properties=dict())
```

Before:
```
{'type': 'Point', 'coordinates': (-118.49893624671255, 34.016682803881345), 'properties': {}, 'geometry': {'coordinates': [-118.49893624671255, 34.016682803881345]}}
```

`coordinates` shows up twice, no `type` in `geometry` dict

After:
```
{'type': 'Feature', 'properties': {}, 'geometry': {'coordinates': [-118.46020348045734, 34.02977299188758], 'type': 'Point'}}
```
