### PR TITLE
Revert extract_point changes

### DIFF
--- a/mds/json.py
+++ b/mds/json.py
@@ -41,7 +41,9 @@ def extract_point(feature):
     """
     Extract the coordinates from the given GeoJSON :feature: as a shapely.geometry.Point
     """
-    return shapely.geometry.shape(feature)
+    coords = feature["geometry"]["coordinates"]
+    return shapely.geometry.Point(coords[0], coords[1])
+
 
 def to_feature(shape, properties={}):
     """


### PR DESCRIPTION
With the fixes to `to_feature`, `extract_point` then failed. Turns out we don't need this part of the change introduced by https://github.com/remix/mds-provider/pull/3. Verified this works end-to-end: generates valid geoJSON that can be extracted by the ETL pipeline.