### PR TITLE
Al fixes

### DIFF
--- a/mds/encoding.py
+++ b/mds/encoding.py
@@ -110,20 +110,19 @@ class TimestampEncoder():
                 Datetime to encode.
 
         Return:
-            str
+            int | str
         """
-        import pdb; pdb.set_trace()
         if self.date_format == "unix":
             if self.version < Version("0.3.0"):
-                return str(int(data.timestamp()))
+                return int(data.timestamp())
             else:
-                return str(int(round(data.timestamp() * 1000)))
+                return int(round(data.timestamp() * 1000))
         elif self.date_format == "iso8601":
             return data.isoformat()
         elif self.date_format is not None:
             return data.strftime(self.date_format)
         else:
-            return str(int(data))
+            return int(data)
 
 
 class TimestampDecoder():

--- a/mds/encoding.py
+++ b/mds/encoding.py
@@ -112,6 +112,7 @@ class TimestampEncoder():
         Return:
             str
         """
+        import pdb; pdb.set_trace()
         if self.date_format == "unix":
             if self.version < Version("0.3.0"):
                 return str(int(data.timestamp()))

--- a/mds/github.py
+++ b/mds/github.py
@@ -7,14 +7,15 @@ GITHUB = "https://github.com"
 GITHUB_RAW = "https://raw.githubusercontent.com"
 
 MDS_DEFAULT_REF = "master"
-MDS_ORG_NAME = "CityOfLosAngeles"
+MDS_ORG_NAME = "openmobilityfoundation"
 MDS_REPO_NAME = "mobility-data-specification"
 
 MDS = (GITHUB, MDS_ORG_NAME, MDS_REPO_NAME)
 MDS_RAW = (GITHUB_RAW, MDS_ORG_NAME, MDS_REPO_NAME)
 
 MDS_PROVIDER_REGISTRY = "/".join(MDS_RAW + ("{}/providers.csv",))
-MDS_SCHEMA = "/".join(MDS_RAW + ("{}/provider/{}.json",))
+MDS_OLD_SCHEMA = "/".join(MDS_RAW + ("{}/provider/{}.json",))
+MDS_SCHEMA = "/".join(MDS_RAW + ("{}/provider/dockless/{}.json",))
 
 
 def registry_url(ref=None):
@@ -53,4 +54,41 @@ def schema_url(schema_type, ref=None):
         str
     """
     ref = ref or MDS_DEFAULT_REF
-    return MDS_SCHEMA.format(ref, schema_type)
+
+    if is_pre_mds_040(ref):
+        return MDS_OLD_SCHEMA.format(ref, schema_type)
+    else:
+        return MDS_SCHEMA.format(ref, schema_type)
+
+
+def is_pre_mds_040(ref) -> bool:
+    """
+    Tries to determine if an unknown object is a string that represents
+    MDS 0.2.x or 0.3.x. Reason being that the Open Mobility Foundation
+    changed the URL structure of their repo with v0.4.0 by moving schemas
+    to a 'dockless' folder.
+
+    n.b. is not smart enough to determine if a hash is a reference to an older
+    MDS version.
+
+    Parameters:
+        ref: Any
+                Might be an MDS version. Will be coerced to a string.
+
+    Return:
+        bool
+    """
+
+    str_split = str(ref).split('.')
+
+
+    if not len(str_split) == 3:
+        # not a known mds version
+        return False
+
+    mds_semver = [int(i) for i in str_split]
+
+    if mds_semver[0] == 0 and mds_semver[1] < 4:
+        return True
+
+    return False

--- a/mds/github.py
+++ b/mds/github.py
@@ -1,6 +1,7 @@
 """
 Data and helpers for MDS on GitHub.
 """
+from .versions import Version
 
 
 GITHUB = "https://github.com"
@@ -79,16 +80,18 @@ def is_pre_mds_040(ref) -> bool:
         bool
     """
 
-    str_split = str(ref).split('.')
-
-
-    if not len(str_split) == 3:
-        # not a known mds version
+    # if not a string representation of a version, e.g. 'master'
+    if isinstance(ref, str) and len(ref.split('.')) < 2:
         return False
 
-    mds_semver = [int(i) for i in str_split]
+    if not isinstance(ref, Version):
+        ref = Version(ref)
 
-    if mds_semver[0] == 0 and mds_semver[1] < 4:
-        return True
+    try:
+        if ref < Version('0.4.0'):
+            return True
 
-    return False
+        return False
+    except e:
+        print(f"Unable to determine MDS version from '{ref}', assuming 0.4.0 or greater. Error: {e}")
+        return False


### PR DESCRIPTION
Al added some changes related to MDS 0.4. 

When generating data for staging, I noted that the event_time timestamps for status_changes were being defined as strings, which is not valid based on schema definitions. I updated the return value of TimestampEncoder when the date format is specified as `unix`. This now returns an`int` as is necessary.